### PR TITLE
Moving to __name__ from func_name for python3 compat

### DIFF
--- a/src/atom/__init__.py
+++ b/src/atom/__init__.py
@@ -93,7 +93,7 @@ def v1_deprecated(warning=None):
     # Preserve the original name to avoid masking all decorated functions as
     # 'deprecated_function'
     try:
-      optional_warn_function.func_name = f.func_name
+      optional_warn_function.func_name = f.__name__
     except TypeError:
       pass # In Python2.3 we can't set the func_name
     return optional_warn_function


### PR DESCRIPTION
Copying Repo to jamuseum for local editing and stability over time since this is a deprecated repo.

See here:
https://github.com/google/gdata-python-client/issues/29